### PR TITLE
Update security settings of favonia/cloudflare-ddns

### DIFF
--- a/angannondir/docker-compose.yml
+++ b/angannondir/docker-compose.yml
@@ -35,14 +35,13 @@ services:
   cloudflare-ddns:
     image: favonia/cloudflare-ddns:latest
     container_name: angannondir-cloudflare
+    user: "${PUID:-1000}:${PGID:-1000}"
     cap_drop:
       - all
     environment:
       CF_API_TOKEN: ${ANGANNONDIR_CLOUDFLARE_TOKEN:-changeMe}
       DOMAINS: ${DOMAINS:-changeMe.biz}
-      PGID: ${PGID:-1000}
       PROXIED: "TRUE"
-      PUID: ${PUID:-1000}
       TZ: ${TZ:-America/Los_Angeles}
       IP6_PROVIDER: "none"
     network_mode: host


### PR DESCRIPTION
Thanks for using my DDNS updater. Since [version 1.13.0](https://github.com/favonia/cloudflare-ddns/blob/main/CHANGELOG.markdown#1130-2024-07-16) (released on 16 July), the updater has stopped dropping superuser privileges by itself, instead relying on Docker's built-in mechanism to drop those privileges. The new way is safer, cleaner, and more reliable; but it requires an update to the configuration. In particular, the environment variables `PUID=uid` and `PGID=gid` should be replaced by `user: "uid:gid"` or `--user uid:gid`. I am on a mission to eliminate the old template from the internet. Please help me promote security best practices!

For more information about this design change, please read the [CHANGELOG](https://github.com/favonia/cloudflare-ddns/blob/main/CHANGELOG.markdown). If copyright ever matters, this PR itself is licensed under [CC0](https://choosealicense.com/licenses/cc0-1.0/), which should allow you to do whatever you want. Thank you again for your interest in the updater.